### PR TITLE
0.0.10

### DIFF
--- a/WordNotifications.plugin.js
+++ b/WordNotifications.plugin.js
@@ -8,7 +8,7 @@ class WordNotifications {
         return "Get notifications when certain words are said.";
     }
     getVersion() {
-        return "0.0.9";
+        return "0.0.10";
     }
     getAuthor() {
         return "Qwerasd";
@@ -26,7 +26,8 @@ class WordNotifications {
     start() {
         this.cancelPatch = BdApi.monkeyPatch(BdApi.findModuleByProps("dispatch"), 'dispatch', { after: this.dispatch.bind(this) });
         this.words = BdApi.loadData('WordNotifications', 'words') || [];
-        this.blacklist = BdApi.loadData('WordNotifications', 'blacklist') || [];
+        this.user_blacklist = BdApi.loadData('WordNotifications', 'user_blacklist') || [];
+        this.guild_blacklist = BdApi.loadData('WordNotifications', 'guild_blacklist') || [];
     }
     stop() {
         this.cancelPatch();
@@ -40,7 +41,9 @@ class WordNotifications {
         if (data.methodArguments[0].type !== 'MESSAGE_CREATE')
             return;
         const message = data.methodArguments[0].message;
-        if (this.blacklist.includes(message.guild_id))
+        if (this.user_blacklist.includes(message.author.id))
+            return;
+        if (this.guild_blacklist.includes(message.guild_id))
             return;
         if (this.currentChannel() === message.channel_id && require('electron').remote.getCurrentWindow().isFocused())
             return;
@@ -79,8 +82,10 @@ class WordNotifications {
         const div = document.createElement('div');
         const wordsT = document.createElement('h6');
         const words = document.createElement('textarea');
-        const ignoreT = document.createElement('h6');
-        const ignore = document.createElement('textarea');
+        const guild_ignoreT = document.createElement('h6');
+        const guild_ignore = document.createElement('textarea');
+        const user_ignoreT = document.createElement('h6');
+        const user_ignore = document.createElement('textarea');
         const br = document.createElement('br');
         const button = document.createElement('button');
         button.innerText = 'Apply';
@@ -95,26 +100,39 @@ class WordNotifications {
         words.style.minHeight = '6ch';
         words.style.color = 'black';
         words.style.backgroundColor = 'white';
-        ignoreT.innerText = 'Ignored Servers';
-        ignoreT.style.marginTop = '0.5ch';
-        ignoreT.style.marginBottom = '0.25ch';
-        ignore.placeholder = '(Optional) List of server IDs to ignore (e.g. "86004744966914048, 280806472928198656")';
-        ignore.value = this.blacklist.join(', ');
-        ignore.style.width = '100%';
-        ignore.style.minHeight = '6ch';
-        ignore.style.color = 'black';
-        ignore.style.backgroundColor = 'white';
+        guild_ignoreT.innerText = 'Ignored Servers';
+        guild_ignoreT.style.marginTop = '0.5ch';
+        guild_ignoreT.style.marginBottom = '0.25ch';
+        guild_ignore.placeholder = '(Optional) List of server IDs to ignore (e.g. "86004744966914048, 280806472928198656")';
+        guild_ignore.value = this.guild_blacklist.join(', ');
+        guild_ignore.style.width = '100%';
+        guild_ignore.style.minHeight = '6ch';
+        guild_ignore.style.color = 'black';
+        guild_ignore.style.backgroundColor = 'white';
+        user_ignoreT.innerText = 'Ignored Servers';
+        user_ignoreT.style.marginTop = '0.5ch';
+        user_ignoreT.style.marginBottom = '0.25ch';
+        user_ignore.placeholder = '(Optional) List of user IDs to ignore (e.g. "86004744966914048, 280806472928198656")';
+        user_ignore.value = this.user_blacklist.join(', ');
+        user_ignore.style.width = '100%';
+        user_ignore.style.minHeight = '6ch';
+        user_ignore.style.color = 'black';
+        user_ignore.style.backgroundColor = 'white';
         button.addEventListener('click', _ => {
             this.words = words.value.split(',').map(e => e.trim());
             BdApi.saveData('WordNotifications', 'words', this.words);
-            this.blacklist = ignore.value.split(',').map(e => e.trim());
-            BdApi.saveData('WordNotifications', 'blacklist', this.blacklist);
+            this.guild_blacklist = guild_ignore.value.split(',').map(e => e.trim());
+            BdApi.saveData('WordNotifications', 'guild_blacklist', this.guild_blacklist);
+            this.user_blacklist = user_ignore.value.split(',').map(e => e.trim());
+            BdApi.saveData('WordNotifications', 'user_blacklist', this.user_blacklist);
             document.getElementById('plugin-settings-Word Notifications').previousSibling.click();
         });
         div.appendChild(wordsT);
         div.appendChild(words);
-        div.appendChild(ignoreT);
-        div.appendChild(ignore);
+        div.appendChild(guild_ignoreT);
+        div.appendChild(guild_ignore);
+        div.appendChild(user_ignoreT);
+        div.appendChild(user_ignore);
         div.appendChild(br);
         div.appendChild(button);
         return div;


### PR DESCRIPTION
allow users to block users by ID  
adds a new field in the settings to add user IDs, made to mimic the server ID field  
renames the `blacklist` variable to `guild_blacklist` --> users will have to reconfigure  
adds a `user_blacklist` variable